### PR TITLE
fix(SpanAPI): make SpanAPI write-only

### DIFF
--- a/span-api.ts
+++ b/span-api.ts
@@ -1,7 +1,6 @@
 import { Attribute, Attributes } from "./deps.ts";
 import { SpanContextAPI } from "./span-context.ts";
 import { SpanEvent } from "./span-event.ts";
-import { SpanKind } from "./span-kind.ts";
 import { SpanLink } from "./span-link.ts";
 import { SpanStatus } from "./span-status.ts";
 import { Timestamp } from "./types.ts";
@@ -13,19 +12,9 @@ export class SpanAttributes extends Attributes {}
  * This is described at https://opentelemetry.io/docs/specs/otel/trace/api/#span
  */
 export interface SpanAPI {
-  readonly name: string;
-  readonly spanContext: SpanContextAPI;
-  readonly parent: SpanAPI | SpanContextAPI | null;
-  readonly spanKind: SpanKind;
-  readonly start: Timestamp;
-  readonly end: Timestamp | null;
-  readonly attributes: SpanAttributes;
-  readonly links: SpanLink[];
-  readonly events: SpanEvent[];
-  readonly status: SpanStatus;
-  readonly isRecording: boolean;
-
   getSpanContext(): SpanContextAPI;
+  isRecording(): boolean;
+
   setAttribute(key: string, value: unknown): void;
   setAttributes(attributes: Attribute[]): void;
   addLink(


### PR DESCRIPTION
The SDK makes it clear that the SpanAPI should be (mostly) write-only, so this change implements that

BREAKING CHANGE: Fixes #1; this changes SpanAPI so will likely break dependent code